### PR TITLE
Action Working Directory vs. Relative Paths

### DIFF
--- a/.github/workflows/use-action.yaml
+++ b/.github/workflows/use-action.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '1.18'
-      - uses: imjasonh/setup-ko@v0.4
+      - uses: imjasonh/setup-ko@v0.6
 
       # checking out the project code on the current workspace
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
         with:
           go-version: '1.18'
       # ko is a dependency to deploy the build controller instance
-      - uses: imjasonh/setup-ko@v0.4
+      - uses: imjasonh/setup-ko@v0.6
 
       # setting up Shipwright Build Controller, CLI and a Container Registry
       - uses: shipwright-io/setup@v0

--- a/action.yaml
+++ b/action.yaml
@@ -30,19 +30,22 @@ runs:
   steps:
     # pre-flight checks, making sure the dependencies needed for the upcoming steps are available
     - shell: bash
-      run: ${{ github.action_path }}/probe.sh
+      working-directory: ${{ github.action_path }}
+      run: ./probe.sh
 
     # deploying the container registry when input flag is set, waiting for the deployment to reach
     # ready status before proceeding
     - shell: bash
       if: ${{ inputs.setup-registry == 'true' }}
-      run: ${{ github.action_path }}/install-registry.sh
+      working-directory: ${{ github.action_path }}
+      run: ./install-registry.sh
 
     # deploying tekton pipline controller and dependencies, waiting for it to reach ready status
     - shell: bash
       env:
         TEKTON_VERSION: ${{ inputs.tekton-version }}
-      run: ${{ github.action_path }}/install-tekton.sh
+      working-directory: ${{ github.action_path }}
+      run: ./install-tekton.sh
 
     # checking out the build controller project locally to perform the rollout and inspection of the
     # controller instance in the cluster
@@ -55,7 +58,8 @@ runs:
     - shell: bash
       env:
         KIND_CLUSTER_NAME: ${{ inputs.kind-cluster-name }}
-      run: ${{ github.action_path }}/install-shipwright.sh
+      working-directory: ${{ github.action_path }}
+      run: ./install-shipwright.sh
 
     # checking out the CLI project locally, performing the installation to let it available on PATH
     - uses: actions/checkout@v3
@@ -65,4 +69,5 @@ runs:
         path: src/cli
       if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
     - shell: bash
-      run: ${{ github.action_path }}/install-cli.sh
+      working-directory: ${{ github.action_path }}
+      run: ./install-cli.sh


### PR DESCRIPTION
# Changes

This action `v0` fails to find the shell scripts in relative paths, this pull-request is adopting `working-directory` attribute to the same file-system path the action is checked out. In GitHub Actions the location where the action lays is shared via [github.action_path](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context).

Additionally, updating `imjasonh/setup-ko` to the latest release (`v0.6`).

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```