### PR TITLE
Skipping Steps with `_ignore` Input Value

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,17 @@ The Shipwright components [Build Controller][shpBuild] and [CLI][shpCLI] can be 
 
 ### Inside the Shipwright Organization
 
-This action inspects the current context before checking out the [Build Controller][shpBuild] and the [CLI][shpCLI] repositories, so when it's being executed against forks or the actual repositories, the action uses the local data.
+By default the action execute a checkout of the Build and CLI repositories, however when working on those specific projects you can skip using `_ignore`. As the following example:
 
-In other words, this action only performs the remote repository checkout, and therefore can be employed on the [`shipwright-io` organization][shpGitHubOrg] and as well repository forks you're working on.
+```yml
+jobs:
+  use-action:
+    steps:
+      - uses: shipwright-io/setup@v1
+        with:
+          shipwright-ref: _ignore
+          cli-ref: _ignore
+```
 
 ## Contributing
 

--- a/action.yaml
+++ b/action.yaml
@@ -54,11 +54,12 @@ runs:
         repository: shipwright-io/build
         ref: ${{ inputs.shipwright-ref }}
         path: src/build
-      if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+      if: ${{ inputs.shipwright-ref != '_ignore' }}
     - shell: bash
       env:
         KIND_CLUSTER_NAME: ${{ inputs.kind-cluster-name }}
       working-directory: ${{ github.action_path }}
+      if: ${{ inputs.shipwright-ref != '_ignore' }}
       run: ./install-shipwright.sh
 
     # checking out the CLI project locally, performing the installation to let it available on PATH
@@ -67,7 +68,8 @@ runs:
         repository: shipwright-io/cli
         ref: ${{ inputs.cli-ref }}
         path: src/cli
-      if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+      if: ${{ inputs.cli-ref != '_ignore' }}
     - shell: bash
       working-directory: ${{ github.action_path }}
+      if: ${{ inputs.cli-ref != '_ignore' }}
       run: ./install-cli.sh


### PR DESCRIPTION
# Changes

Determining which projects should skip getting cloned and installed by using `_ignore` input value. Simplifying the current approach of automatically detecting repository clones with a explicit setting.

# Submitter Checklist

- [x] ~Includes tests if functionality changed/was added~
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Supporting special value `_ignore` for `shipwright-ref` and `cli-ref` inputs, when `_ignore` is passed the respective step will be skipped.
```
