### PR TITLE
Patching Container Registry Hostname in /etc/hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,21 @@ jobs:
           cli-ref: v0.11.0
           kind-cluster-name: kind
           setup-registry: true
+          registry-hostname: registry.registry.svc.cluster.local
+          patch-etc-hosts: true
 ```
 
 The inputs are described below:
 
-| Input               | Default   | Description                                                   |
-|---------------------|-----------|---------------------------------------------------------------|
-| `tekton-version`    | `v0.38.3` | [Tekton Pipeline][tektonPipeline] release version             |
-| `shipwright-ref`    | `v0.11.0` | [Shipwright Build Controller][shpBuild] repository tag or SHA |
-| `cli-ref`           | `v0.11.0` | [Shipwright CLI][shpCLI] repository tag or SHA                |
-| `kind-cluster-name` | `kind`    | KinD cluster name                                             |
-| `setup-registry`    | `true`    | Setup a Container Registry instance (`true` or `false`)       |
+| Input               | Default                               | Description                                                                |
+| ------------------- | ------------------------------------- | -------------------------------------------------------------------------- |
+| `tekton-version`    | `v0.38.3`                             | [Tekton Pipeline][tektonPipeline] release version                          |
+| `shipwright-ref`    | `v0.11.0`                             | [Shipwright Build Controller][shpBuild] repository tag or SHA              |
+| `cli-ref`           | `v0.11.0`                             | [Shipwright CLI][shpCLI] repository tag or SHA                             |
+| `kind-cluster-name` | `kind`                                | KinD cluster name                                                          |
+| `setup-registry`    | `true`                                | Setup a Container Registry instance (`true` or `false`)                    |
+| `registry-hostname` | `registry.registry.svc.cluster.local` | Container Registry hostname inside KinD                                    |
+| `patch-etc-hosts`   | `true`                                | Patch "/etc/hosts" to alias the Container Registry hostname to "127.0.0.1" |
 
 The Shipwright components [Build Controller][shpBuild] and [CLI][shpCLI] can be deployed using a specific commit SHA or tag.
 

--- a/action.yaml
+++ b/action.yaml
@@ -25,6 +25,14 @@ inputs:
     description: When enabled, the action deploys a Container Registry instance
     required: true
     default: "true"
+  registry-hostname:
+    description: Container Registry hostname inside KinD
+    required: true
+    default: registry.registry.svc.cluster.local
+  patch-etc-hosts:
+    description: Patch "/etc/hosts" to alias the Container Registry hostname to "127.0.0.1"
+    required: true
+    default: "true"
 runs:
   using: composite
   steps:
@@ -46,6 +54,14 @@ runs:
         TEKTON_VERSION: ${{ inputs.tekton-version }}
       working-directory: ${{ github.action_path }}
       run: ./install-tekton.sh
+
+    # patches the /etc/hosts to include the container registry hostname resolving to 127.0.0.1
+    - shell: bash
+      if: ${{ inputs.patch-etc-hosts == 'true' }}
+      env:
+        REGISTRY_HOSTNAME: ${{ inputs.registry-hostname }}
+      working-directory: ${{ github.action_path }}
+      run: sudo ./patch-etc-hosts.sh
 
     # checking out the build controller project locally to perform the rollout and inspection of the
     # controller instance in the cluster

--- a/assert.sh
+++ b/assert.sh
@@ -10,6 +10,11 @@ source common.sh
 echo "# Asserting the Container Registry rollout status..."
 rollout_status "${REGISTRY_NAMESPACE}" "registry"
 
+echo "# Asserting the /etc/hosts have been patched..."
+if ! grep -E -q '127\.0\.0\.1.*registry' /etc/hosts ; then
+	fail "/etc/hosts does not include the registry hostname"
+fi
+
 echo "# Asserting the Tekton Pipeline Controller"
 rollout_status "${TEKTON_NAMESPACE}" "tekton-pipelines-controller"
 

--- a/patch-etc-hosts.sh
+++ b/patch-etc-hosts.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Patches /etc/hosts to include the registry FQDN resolving to localhost.
+#
+
+set -eu -o pipefail
+set -x
+
+REGISTRY_HOSTNAME=${REGISTRY_HOSTNAME:-registry.registry.svc.cluster.local}
+HOSTS_ENTRY="127.0.0.1    ${REGISTRY_HOSTNAME}"
+
+readonly ETC_HOSTS="/etc/hosts"
+
+if ! grep -q "${HOSTS_ENTRY}" ${ETC_HOSTS} ; then
+	echo "${HOSTS_ENTRY}" |tee -a ${ETC_HOSTS}
+fi


### PR DESCRIPTION
# Changes

Patching `/etc/hosts` to alias the Container Registry hostname to `127.0.0.1`, a required setup to run complete end-to-end tests.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Adding input `patch-etc-hosts` and `registry-hostname` to control wether amend the informed hostname in local `/etc/hosts`, aliasing the hostname to 127.0.0.1
```
