### PR TITLE
Automatically create tags on push to main branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+---
+name: release
+
+on:
+  push:
+    tags-ignore:
+      - '**'
+    paths-ignore:
+      - '**.md'
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'shipwright-io/setup' }}
+    env:
+      VERSION: "1"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: git-configuration
+        run: |
+          git config user.name ${{ github.actor }}
+          git config user.email ${{ github.actor }}@users.noreply.github.com
+
+      - name: release-action
+        working-directory: ${{ github.action_path }}
+        run: |
+          eval "$(./hack/release.sh)"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Copyright The Shipwright Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Based on the major version informed, this script prints out the git commands needed to update the
+# current major version tag, and also, release a minor subsequent tag.
+#
+
+set -euo pipefail
+
+# major project version and git tag name, based on it
+VERSION="${VERSION:-1}"
+readonly MAJOR_TAG="v${VERSION}"
+
+# making sure the local git tags are updated
+git fetch --tags
+
+echo "# Preparing release for '${MAJOR_TAG}' (major)..."
+
+# checking if there are mnior release tags, based on the major release
+LAST_TAG="$(git tag --list --sort=v:refname | grep "${MAJOR_TAG}." | tail -n 1)"
+
+if [ "${LAST_TAG}" == "" ]; then
+  NEXT_TAG="${MAJOR_TAG}.0"
+else
+  echo "# Last tag '${LAST_TAG}'"
+
+  LAST_TAG_MINOR="${LAST_TAG/${MAJOR_TAG}./}"
+  NEXT_TAG_MINOR=$((LAST_TAG_MINOR + 1))
+  NEXT_TAG="${MAJOR_TAG}.${NEXT_TAG_MINOR}"
+fi
+
+echo "# Updating major '${MAJOR_TAG}' and tagging '${NEXT_TAG}'..."
+cat <<EOS
+git tag --force "v${VERSION}"
+git push --force origin "v${VERSION}"
+
+git tag "${NEXT_TAG}"
+git push origin "${NEXT_TAG}"
+EOS


### PR DESCRIPTION
# Changes

Adding a GitHub action that updates tags on push to main:

- v1 is overwritten
- v1.n is added. This will add v1.0 if no v1.n exists, otherwise it will take the tag with the largest n and increment it

There is an environment variable VERSION that is the single place that would need to be changed to "2" to bump the major version of the action.

Tests were performed here: https://github.com/SaschaSchwarze0/shipwright-io-setup/actions/workflows/release.yaml

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Adding a GitHub action that takes care of the tagging
```