### PR TITLE
Release Script Fix

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -21,7 +21,7 @@ git fetch --tags
 echo "# Preparing release for '${MAJOR_TAG}' (major)..."
 
 # checking if there are mnior release tags, based on the major release
-LAST_TAG="$(git tag --list --sort=v:refname | grep "${MAJOR_TAG}." | tail -n 1)"
+LAST_TAG="$(git tag --list --sort=v:refname | { grep "${MAJOR_TAG}." || :; } | tail -n 1)"
 
 if [ "${LAST_TAG}" == "" ]; then
   NEXT_TAG="${MAJOR_TAG}.0"


### PR DESCRIPTION
# Changes

Making sure `grep` does not error out when the string it's searching for is not found, this was
preventing the script to run successfully due to enabled `pipefail` bash option.

# Submitter Checklist

- [x] ~Includes tests if functionality changed/was added~
- [x] ~Includes docs if changes are user-facing~
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```