### PR TITLE
Use Go `1.22` in GitHub Actions

### DIFF
--- a/.github/workflows/use-action.yaml
+++ b/.github/workflows/use-action.yaml
@@ -29,7 +29,7 @@ jobs:
       # installing go and ko, both action dependencies
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 1.22.x
       - uses: imjasonh/setup-ko@v0.6
 
       # checking out the project code on the current workspace


### PR DESCRIPTION
# Changes

Use latest Go version `1.22` for any Go related GitHub Action.

/kind dependency-change

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
